### PR TITLE
Aa/add expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ console.log( mem() );
 console.log( mem() ); // Same value as above
 
 setTimeout( function() {
-  console.log( mem() );
-}, 1001 ); // Different value
+  console.log( mem() ); // Different value
+}, 1001 );
 ```

--- a/README.md
+++ b/README.md
@@ -39,3 +39,23 @@ let mem = memoize( loop );
 console.log( mem( Math.sqrt, 1e9 ) ); // slow
 console.log( mem( Math.sqrt, 1e9 ) ); // fast!
 ```
+
+### Example with expire time in milliseconds
+
+```js
+'use strict';
+
+const memoize = require('map-memo');
+
+function getRandom() {
+  return Math.random();
+}
+
+let mem = memoize( getRandom, { ttl: 1000 } );
+console.log( mem() );
+console.log( mem() ); // Same value as above
+
+setTimeout( function() {
+  console.log( mem() );
+}, 1001 ); // Different value
+```

--- a/lib/map-memo.js
+++ b/lib/map-memo.js
@@ -28,7 +28,7 @@ class Cache {
 
 module.exports = function memoize( fn, opts ) {
   const cache = new Cache();
-  opts = Object.assign( {}, opts );
+  opts = Object.assign( { ttl: Infinity }, opts );
 
   return function() {
     const args = new Array( arguments.length );
@@ -44,7 +44,7 @@ module.exports = function memoize( fn, opts ) {
       return item.value;
     }
 
-    item.expires = Date.now() + ( opts.ttl || Infinity );
+    item.expires = Date.now() + opts.ttl;
     return item.value = fn.apply( this, args );
   };
 };

--- a/lib/map-memo.js
+++ b/lib/map-memo.js
@@ -26,8 +26,9 @@ class Cache {
 
 }
 
-module.exports = function memoize( fn ) {
+module.exports = function memoize( fn, opts ) {
   const cache = new Cache();
+  opts = Object.assign( {}, opts );
 
   return function() {
     const args = new Array( arguments.length );
@@ -39,10 +40,11 @@ module.exports = function memoize( fn ) {
     // get (or create) a cache item
     const item = cache.get( args );
 
-    if ( item.hasOwnProperty('value') ) {
+    if ( item.hasOwnProperty('value') && item.expires >= Date.now() ) {
       return item.value;
     }
 
+    item.expires = Date.now() + ( opts.ttl || Infinity );
     return item.value = fn.apply( this, args );
   };
 };

--- a/test/test.js
+++ b/test/test.js
@@ -130,4 +130,21 @@ describe( 'memoize', () => {
     assert.equal( first, second, 'Cached result is incorrect' );
   });
 
+  it( 'should expire an element after a ttl' , done => {
+    let fn = function() {
+      return Math.random();
+    }
+    let mem = memoize( fn, { ttl: 10 } );
+
+    let first = mem();
+    let second = mem();
+    assert.equal( first, second );
+
+    setTimeout( function() {
+      let newFirst = mem();
+
+      assert.notEqual( first, newFirst );
+      done();
+    }, 11 );
+  });
 });


### PR DESCRIPTION
This will add an options hash optional parameter that has support for a `ttl` value in milliseconds. 

It will refresh the function call if the ttl has expired since it was cached. Everything defaults to `Infinity` if no ttl is set.
