### PR TITLE
enable dynamic ttl

### DIFF
--- a/lib/map-memo.js
+++ b/lib/map-memo.js
@@ -26,7 +26,7 @@ class Cache {
 
 }
 
-module.exports = function memoize( fn, { ttl = Infinity } = {} ) {
+module.exports = function memoize( fn, opts = {} ) {
   const cache = new Cache();
 
   return function( ...args ) {
@@ -37,7 +37,7 @@ module.exports = function memoize( fn, { ttl = Infinity } = {} ) {
       return item.value;
     }
 
-    item.expires = Date.now() + ttl;
+    item.expires = Date.now() + opts.ttl || Infinity;
     return item.value = fn.apply( this, args );
   };
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "grunt-eslint": "18.1.0",
     "grunt-mocha-istanbul": "4.0.2",
     "istanbul": "0.4.3",
-    "mocha": "2.5.3"
+    "mocha": "2.5.3",
+    "sinon": "8.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-memo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Generic memoization with Map and WeakMap",
   "author": "Kevin Ennis <kennis84@gmail.com",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const sinon = require('sinon');
 const memoize = require('../lib/map-memo');
 
 // sample types
@@ -173,7 +174,8 @@ describe( 'memoize', () => {
     .catch( done );
   });
 
-  it( 'should work with dynamic getter for ttl', done => {
+  it( 'should work with dynamic getter for ttl', () => {
+    const clock = sinon.useFakeTimers();
     let toggle = false;
 
     let count = 0;
@@ -193,26 +195,20 @@ describe( 'memoize', () => {
     assert.equal( count, 1 );
 
     // first cache save will expire after 10ms
-    setTimeout( () => {
-      mem('foo');
-      assert.equal( count, 2 );
-      mem('foo');
-      assert.equal( count, 2 );
+    clock.tick( 20 );
+    mem('foo');
+    assert.equal( count, 2 );
+    mem('foo');
+    assert.equal( count, 2 );
 
-      // prove that 2nd cache save ttl is longer than initial 10ms ttl
-      setTimeout( () => {
-        mem('foo');
-        assert.equal( count, 2 );
-      }, 20 );
+    // prove that 2nd cache save ttl is longer than initial 10ms ttl
+    clock.tick( 20 );
+    mem('foo');
+    assert.equal( count, 2 );
 
-      // prove that 2nd cache save ttl is 200ms
-      setTimeout( () => {
-        mem('foo');
-        assert.equal( count, 3 );
-        done();
-      }, 210 );
-
-    }, 20 );
-
+    // prove that 2nd cache save ttl is 200ms
+    clock.tick( 210 );
+    mem('foo');
+    assert.equal( count, 3 );
   });
 });


### PR DESCRIPTION
adds compatibility for a dynamic `ttl` getter for `map-memo`. The use case i have is to ensure that cache expirations don’t all happen at the same time.

```
const mem = memoize( fn, {
	get ttl() {
		const min = Math.ceil(ONE_DAY - ONE_HOUR);
		const max = Math.floor(ONE_DAY + ONE_HOUR);
		return Math.floor(Math.random() * (max - min + 1)) + min;
	}
});
```